### PR TITLE
fix/auth : use user ID instead username in JWT payload (#12)

### DIFF
--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -68,7 +68,7 @@ def login(form_data: OAuth2PasswordRequestForm = Depends()):
 
     # 2. Token에 담을 내용(Payload) 구성
     # sub(주체, Subject) 키에 유저 고유값 넣기
-    token_data = {"sub": str(user["username"])}
+    token_data = {"sub": str(user["id"])}
 
     # 3. JWT 토큰 생성
     access_token = create_access_token(data=token_data)


### PR DESCRIPTION
- routers/auth.py: Update `/login` endpoint to store `user["id"]` in the JWT `sub` claim instead of `username` to ensure proper stateless authentication.
- dependencies.py: Fix `get_current_user` to correctly cast the extracted `sub` claim to an integer (`int`) matching the database PK type.