### PR TITLE
feat(auth): implement account deletion and enable SQLite foreign keys

### DIFF
--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -2,10 +2,9 @@
 
 from fastapi import APIRouter, Depends, status, HTTPException
 from fastapi.security import OAuth2PasswordRequestForm
-from schemas.auth import UserCreate, TokenResponse
-from crud.auth import create_user, authenticate_user
+from schemas.auth import UserCreate, UserDelete, TokenResponse
+from crud.auth import create_user, authenticate_user, delete_user
 from core.security import create_access_token
-from core.exceptions import UserAlreadyExistsException
 from api.dependencies import get_current_user
 
 
@@ -31,13 +30,7 @@ def signup(user_data: UserCreate):
         UserAlreadyExistsException: (CRUD 내부에서 발생) 이미 존재하는 아이디일 경우 409 반환
     """
 
-    try:
-        new_user = create_user(user_data)
-    except UserAlreadyExistsException as e:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="이미 존재하는 ID입니다."
-        )
+    new_user = create_user(user_data.username, user_data.password, user_data.nickname)
 
     return {
         "message" : "회원가입이 완료되었습니다.",
@@ -97,6 +90,36 @@ def logout():
         "message" : "로그아웃 되었습니다."
     }
 
+@router.delete(
+        "/me",
+        response_model=dict,
+        summary="현재 로그인한 사용자 삭제",
+        description="현재 로그인한 사용자를 DB에서 삭제합니다."
+)
+def withdraw(user_data: UserDelete, current_user_id: int = Depends(get_current_user)):
+    """현재 로그인한 사용자의 계정을 영구 삭제합니다.
+
+    본인 확인을 위해 비밀번호를 입력받으며, 확인이 완료되면 DB에서 유저를 삭제합니다.
+    (연관된 모닥불 및 장작은 DB의 ON DELETE 제약조건에 따라 처리됨)
+
+    Args:
+        user_data (UserDelete): 클라이언트가 전달한 본인 확인용 비밀번호
+        current_user_id (int): Depends를 통해 주입된 현재 로그인 사용자의 고유 ID
+
+    Returns:
+        dict: 회원 탈퇴 성공 메시지
+
+    Raises:
+        InvalidCredentialException: (CRUD 내부에서 발생) 비밀번호가 틀릴 경우 401 반환
+    """
+    
+    delete_user(user_data.password, current_user_id)
+    
+    return {
+        "message" : "회원 탈퇴가 완료되었습니다."
+    }
+    
+    
 @router.get(
     "/me",
     summary="현재 로그인한 사용자 정보 조회",

--- a/crud/auth.py
+++ b/crud/auth.py
@@ -1,23 +1,26 @@
 # 유저 생성, 조회 쿼리
 
 import sqlite3
-from schemas.auth import UserCreate
+from schemas.auth import UserCreate, UserDelete
 from db.connection import get_db_connection
 from core.exceptions import (
     UserAlreadyExistsException,
     UsernameAlreadyExistsException,
     NicknameAlreadyExistsException,
+    UserNotFoundException,
     InvalidCredentialsException
 )
 from core.security import get_password_hash, verify_password
 
-def create_user(user_data: UserCreate) -> dict:
+def create_user(username, password, nickname) -> dict:
     """ 새로운 사용자를 DB에 생성합니다.
 
     입력받은 평문 비밀번호는 내부적으로 단방향 해싱(bcrypt) 처리되어 저장됩니다.
 
     Args:
-        user_data (UserCreate): 가입할 사용자의 정보(username, password, nickname)가 담긴 스키마
+        username (str): 가입할 사용자의 ID
+        password (str): 가입할 사용자의 평문 비밀번호
+        nickname (str): 가입할 사용자의 닉네임
          
     Returns:
         dict: 생성된 사용자의 정보 (password_hash는 제외)
@@ -27,7 +30,7 @@ def create_user(user_data: UserCreate) -> dict:
     """
     
     # 1. 비밀번호 해싱
-    hashed_password = get_password_hash(user_data.password)
+    hashed_password = get_password_hash(password)
 
     # 2. DB Connection 열어서 쿼리를 실행하기
     try:
@@ -36,24 +39,24 @@ def create_user(user_data: UserCreate) -> dict:
 
             # 2-1. username 또는 nickname의 중복을 걸러내기 위해 조회
             query = "SELECT username, nickname FROM users WHERE username = ? OR nickname = ?"
-            cursor.execute(query, (user_data.username, user_data.nickname))
+            cursor.execute(query, (username, nickname))
             existing_user = cursor.fetchone()
 
             # 2-2. 중복 발견 시
             if existing_user:
 
                 # 2-2-1. username 중복 시
-                if existing_user['username'] == user_data.username:
+                if existing_user['username'] == username:
                     raise UsernameAlreadyExistsException()
 
                 # 2-2-2. nickname 중복 시
-                if existing_user['nickname'] == user_data.nickname:
+                if existing_user['nickname'] == nickname:
                     raise NicknameAlreadyExistsException()
 
             # INSERT 쿼리
             # SQL Injection 방지를 위하여 '?' placeholder 사용
             query = "INSERT INTO users (username, password_hash, nickname) VALUES (?, ?, ?)"
-            cursor.execute(query, (user_data.username, hashed_password, user_data.nickname))
+            cursor.execute(query, (username, hashed_password, nickname))
 
             # 변경사항 저장
             conn.commit()
@@ -67,8 +70,8 @@ def create_user(user_data: UserCreate) -> dict:
     
     return {
         "id": new_user_id,
-        "username": user_data.username,
-        "nickname": user_data.nickname
+        "username": username,
+        "nickname": nickname
     }
     
 
@@ -118,3 +121,46 @@ def authenticate_user(username: str, password: str) -> dict:
         "username": db_username,
         "nickname": db_nickname
     }
+
+def delete_user(plain_password: str, user_id: int):
+    """유저 ID와 비밀번호를 검증한 후, DB에서 유저를 영구 삭제합니다.
+
+    Args:
+        password (str): 본인 확인을 위한 평문 비밀번호
+        user_id (int): 삭제할 유저의 고유 ID
+
+    Raises:
+        InvalidCredentialsException: 비밀번호가 일치하지 않을 때 발생
+        UserNotFoundException: 해당 유저가 DB에 없을 때 발생
+    
+    """
+
+    with get_db_connection() as conn:
+        try:
+            cursor = conn.cursor()
+
+            # 1. hashed_password 가져오기
+            query = "SELECT password_hash FROM users WHERE id = ?"
+            cursor.execute(query, (user_id, ))
+            user_record = cursor.fetchone()
+
+            hashed_password = user_record['password_hash']
+
+            # 2. DB에 해당 유저가 없다면 (그럴 일은 없곘지만 혹시)
+            if hashed_password is None:
+                raise UserNotFoundException()
+
+            # 3. plain password와 hashed password 비교
+            if not verify_password(plain_password, hashed_password):
+                raise InvalidCredentialsException()
+            
+            # 4. 유저 삭제
+            query = "DELETE FROM users WHERE id = ?"
+            cursor.execute(query, (user_id, ))
+            conn.commit()
+
+        except Exception as e:
+        
+            conn.rollback()
+            raise e
+        

--- a/db/connection.py
+++ b/db/connection.py
@@ -2,6 +2,7 @@
 
 import sqlite3
 from contextlib import contextmanager
+from core.exceptions import ResourceAccessError
 
 DB_FILENAME = "modakbul.db"
 
@@ -13,14 +14,12 @@ def get_db_connection():
     """
     conn = sqlite3.connect(DB_FILENAME)
     conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
     try:
         yield conn
     finally:
         conn.close()
 
-#setting
-import sqlite3
-from core.exceptions import ResourceAccessError
 
 def check_db_connection(db_url: str):
     try:

--- a/schemas/auth.py
+++ b/schemas/auth.py
@@ -7,6 +7,10 @@ class UserCreate(BaseModel):
     password: str
     nickname: str
 
+class UserDelete(BaseModel):
+    password: str
+
 class TokenResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"
+

--- a/schemas/comments.py
+++ b/schemas/comments.py
@@ -10,5 +10,5 @@ class CommentResponse(BaseModel):
     id: int
     content: str
     created_at: datetime
-    user_id: int
+    user_id: int | None = None
     topic_id: int

--- a/schemas/topics.py
+++ b/schemas/topics.py
@@ -14,7 +14,7 @@ class TopicResponse(BaseModel):
     expires_at: datetime
     comment_count: int
     created_at: datetime
-    user_id: int
+    user_id: int | None = None
 
 class TopicDetailResponse(TopicResponse):
     comments: List[CommentResponse]


### PR DESCRIPTION
- Add `UserDelete` schema to validate password during account withdrawal
- Implement `/auth/me` endpoint and `delete_user` CRUD logic
- Add `PRAGMA foreign_keys = ON` in `get_db_connection` to ensure `ON DELETE SET NULL` works correctly for associated topics and comments

Resolves #25 